### PR TITLE
support VRChat 2022.4.2

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,9 @@ impl LocalLowVRChat {
 
     fn list_logfile_paths(&self) -> Result<Vec<PathBuf>> {
         lazy_static! {
-            static ref RE: Regex = Regex::new("^output_log_\\d{2}-\\d{2}-\\d{2}\\.txt$").unwrap();
+            static ref RE: Regex =
+                Regex::new("^output_log_(\\d{2}-\\d{2}-\\d{2}|\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})\\.txt$")
+                    .unwrap();
         }
         self.vrchat_path
             .read_dir()?


### PR DESCRIPTION
Support for new file names in VRChat 2022.4.2.

https://docs.vrchat.com/docs/vrchat-202242#features

<dl>
  <dt>Old filename</dt>
  <dd><code>output_log_20-27-28.txt</code></dd>

  <dt>New filename</dt>
  <dd><code>output_log_2023-01-07_14-36-12.txt</code></dd>
</dl>